### PR TITLE
[feat] Add custom transcription prompts with menu bar UI

### DIFF
--- a/VoicePaste/APIKeyStore.swift
+++ b/VoicePaste/APIKeyStore.swift
@@ -17,15 +17,20 @@ enum APIKeyStoreError: Error {
 /// Stores API key in plaintext with owner-only permissions to avoid Keychain prompts.
 enum APIKeyStore {
     private static let appName = "VoicePaste"
-    private static let fileName = "api_key"
+    private static let apiKeyFileName = "api_key"
+    private static let promptFileName = "prompt"
 
     private static var storageDirectory: URL {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         return appSupport.appendingPathComponent(appName)
     }
 
-    private static var storageURL: URL {
-        storageDirectory.appendingPathComponent(fileName)
+    private static var apiKeyURL: URL {
+        storageDirectory.appendingPathComponent(apiKeyFileName)
+    }
+
+    private static var promptURL: URL {
+        storageDirectory.appendingPathComponent(promptFileName)
     }
 
     static func saveAPIKey(_ key: String) throws {
@@ -46,7 +51,7 @@ enum APIKeyStore {
         }
 
         // Write atomically with owner-only permissions
-        let fileURL = storageURL
+        let fileURL = apiKeyURL
         do {
             try trimmedKey.write(to: fileURL, atomically: true, encoding: .utf8)
             // Set file permissions to owner read/write only (0600)
@@ -57,7 +62,7 @@ enum APIKeyStore {
     }
 
     static func loadAPIKey() -> String? {
-        let fileURL = storageURL
+        let fileURL = apiKeyURL
         guard FileManager.default.fileExists(atPath: fileURL.path) else {
             return nil
         }
@@ -71,7 +76,63 @@ enum APIKeyStore {
     }
 
     static func deleteAPIKey() throws {
-        let fileURL = storageURL
+        let fileURL = apiKeyURL
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return
+        }
+
+        do {
+            try FileManager.default.removeItem(at: fileURL)
+        } catch {
+            throw APIKeyStoreError.deleteFailed
+        }
+    }
+
+    // MARK: - Prompt Storage
+
+    static func savePrompt(_ prompt: String) throws {
+        let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPrompt.isEmpty else {
+            try deletePrompt()
+            return
+        }
+
+        // Ensure directory exists
+        let directory = storageDirectory
+        if !FileManager.default.fileExists(atPath: directory.path) {
+            do {
+                try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            } catch {
+                throw APIKeyStoreError.directoryCreationFailed
+            }
+        }
+
+        // Write atomically with owner-only permissions
+        let fileURL = promptURL
+        do {
+            try trimmedPrompt.write(to: fileURL, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+        } catch {
+            throw APIKeyStoreError.writeFailed
+        }
+    }
+
+    static func loadPrompt() -> String? {
+        let fileURL = promptURL
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return nil
+        }
+
+        guard let content = try? String(contentsOf: fileURL, encoding: .utf8) else {
+            return nil
+        }
+
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    static func deletePrompt() throws {
+        let fileURL = promptURL
         guard FileManager.default.fileExists(atPath: fileURL.path) else {
             return
         }

--- a/VoicePaste/VoicePasteApp.swift
+++ b/VoicePaste/VoicePasteApp.swift
@@ -295,7 +295,7 @@ struct MenuContent: View {
 
             TextField("Names, terms to improve accuracy...", text: $transcriptionPrompt, axis: .vertical)
                 .textFieldStyle(.roundedBorder)
-                .lineLimit(1...3)
+                .lineLimit(1...8)
 
             HStack {
                 Button("Save") {

--- a/VoicePaste/VoicePasteApp.swift
+++ b/VoicePaste/VoicePasteApp.swift
@@ -293,9 +293,24 @@ struct MenuContent: View {
             Text("Transcription Prompt")
                 .font(.headline)
 
-            TextField("Names, terms to improve accuracy...", text: $transcriptionPrompt, axis: .vertical)
-                .textFieldStyle(.roundedBorder)
-                .lineLimit(1...8)
+            ZStack(alignment: .topLeading) {
+                if transcriptionPrompt.isEmpty {
+                    Text("Names, terms to improve accuracy...")
+                        .foregroundColor(.gray.opacity(0.6))
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 8)
+                }
+                TextEditor(text: $transcriptionPrompt)
+                    .font(.body)
+                    .scrollContentBackground(.hidden)
+            }
+            .frame(minHeight: 60, maxHeight: 120)
+            .background(Color(NSColor.textBackgroundColor))
+            .cornerRadius(5)
+            .overlay(
+                RoundedRectangle(cornerRadius: 5)
+                    .stroke(Color.gray.opacity(0.4), lineWidth: 1)
+            )
 
             HStack {
                 Button("Save") {

--- a/VoicePaste/VoicePasteApp.swift
+++ b/VoicePaste/VoicePasteApp.swift
@@ -250,7 +250,12 @@ struct MenuContent: View {
     @State private var apiKeyInput: String = ""
     @State private var hasAPIKey: Bool = false
     @State private var transcriptionPrompt: String = ""
+    @State private var savedPrompt: String = ""
     @State private var hasPrompt: Bool = false
+
+    private var isPromptModified: Bool {
+        transcriptionPrompt != savedPrompt
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -325,7 +330,11 @@ struct MenuContent: View {
 
                 Spacer()
 
-                if hasPrompt {
+                if isPromptModified {
+                    Text("Modified")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                } else if hasPrompt {
                     Text("Saved")
                         .font(.caption)
                         .foregroundColor(.green)
@@ -388,9 +397,11 @@ struct MenuContent: View {
     private func loadPrompt() {
         if let prompt = APIKeyStore.loadPrompt(), !prompt.isEmpty {
             transcriptionPrompt = prompt
+            savedPrompt = prompt
             hasPrompt = true
         } else {
             transcriptionPrompt = ""
+            savedPrompt = ""
             hasPrompt = false
         }
     }
@@ -398,6 +409,7 @@ struct MenuContent: View {
     private func savePrompt() {
         do {
             try APIKeyStore.savePrompt(transcriptionPrompt)
+            savedPrompt = transcriptionPrompt
             hasPrompt = !transcriptionPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         } catch {
             print("[MenuContent] Failed to save prompt: \(error)")
@@ -409,6 +421,7 @@ struct MenuContent: View {
             try APIKeyStore.deletePrompt()
             hasPrompt = false
             transcriptionPrompt = ""
+            savedPrompt = ""
         } catch {
             print("[MenuContent] Failed to clear prompt: \(error)")
         }

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,44 @@ The animated indicator provides visual feedback that transcription is in progres
 - Network failure: Check your internet connection
 - Audio too large: Whisper has a 25MB file size limit
 
+## Custom Transcription Prompt
+
+VoicePaste supports custom Whisper prompts to improve transcription accuracy for domain-specific vocabulary. This is useful for:
+
+- **Proper nouns**: Names of people, companies, products
+- **Technical terms**: Industry jargon, acronyms, specialized vocabulary
+- **Foreign words**: Non-English names or phrases commonly used in your context
+
+### Setting a Prompt
+
+1. Click the VoicePaste menu bar icon
+2. Enter your prompt text in the "Transcription Prompt" field
+3. Click "Save" to store the prompt
+
+The prompt persists across app launches and is stored in the same Application Support directory as your API key.
+
+### Prompt Tips
+
+- List words with correct spelling: "Anthropic, Claude, Whisper"
+- Include context for ambiguous terms: "The company Anthropic (not anthropic)"
+- Keep prompts concise but descriptive
+- Leave empty to use default Whisper behavior
+
+### Technical Details
+
+When a prompt is configured:
+- The prompt text is sent to OpenAI's Whisper API via the `prompt` field
+- Whisper uses this as a style/vocabulary guide, not instructions
+- Empty prompts are omitted from API requests (no effect on transcription)
+
+### Manual Verification Checklist
+
+- [ ] Click the menu bar icon and verify the "Transcription Prompt" field is visible
+- [ ] Enter a test prompt and click Save
+- [ ] Quit and relaunch the app, verify the prompt persists
+- [ ] Clear the prompt field and click Save
+- [ ] Verify the prompt field is empty after clearing
+
 ## Menu Bar Indicator
 
 On macOS, VoicePaste displays a mic icon in the menu bar to confirm the app is running. The app runs as an agent (no Dock icon) with a minimal menu containing status text and Quit option.

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,5 +10,5 @@ Build and feature verification tests for VoicePaste.
 
 ## Test Files
 
-- `test_build.sh` - Verifies macOS build succeeds and all components are present
+- `test_build.sh` - Verifies macOS build succeeds and all components are present (includes prompt storage and UI checks)
 - `test_permissions.sh` - Manual verification guide for permissions, hotkey, API key (file-based storage), transcription functionality, and animated progress indicator

--- a/tests/test_build.sh
+++ b/tests/test_build.sh
@@ -112,5 +112,34 @@ else
     exit 1
 fi
 
+# Test 10: Verify prompt storage methods exist in APIKeyStore
+echo -n "Test 10: Prompt storage methods in APIKeyStore... "
+if grep -q "savePrompt" "$PROJECT_DIR/VoicePaste/APIKeyStore.swift" && \
+   grep -q "loadPrompt" "$PROJECT_DIR/VoicePaste/APIKeyStore.swift" && \
+   grep -q "deletePrompt" "$PROJECT_DIR/VoicePaste/APIKeyStore.swift"; then
+    echo "PASS"
+else
+    echo "FAIL"
+    exit 1
+fi
+
+# Test 11: Verify OpenAITranscriber supports prompt field
+echo -n "Test 11: OpenAITranscriber prompt support... "
+if grep -q "prompt" "$PROJECT_DIR/VoicePaste/OpenAITranscriber.swift"; then
+    echo "PASS"
+else
+    echo "FAIL"
+    exit 1
+fi
+
+# Test 12: Verify prompt UI exists in menu bar
+echo -n "Test 12: Prompt UI in menu bar... "
+if grep -q "Transcription Prompt\|transcriptionPrompt" "$PROJECT_DIR/VoicePaste/VoicePasteApp.swift"; then
+    echo "PASS"
+else
+    echo "FAIL"
+    exit 1
+fi
+
 echo ""
 echo "=== Build Verification Complete ==="


### PR DESCRIPTION
## Summary

- Add custom Whisper transcription prompt support to improve accuracy for domain-specific vocabulary
- Implement prompt persistence via file-based storage in Application Support directory
- Add "Transcription Prompt" UI field in menu bar settings with Save/Clear buttons

## Changes

| File | Changes |
|------|---------|
| `docs/README.md` | Add Custom Transcription Prompt documentation section |
| `tests/README.md` | Note new prompt-related test checks |
| `tests/test_build.sh` | Add Tests 10-12 for prompt storage, API, and UI |
| `VoicePaste/APIKeyStore.swift` | Add `savePrompt`/`loadPrompt`/`deletePrompt` methods |
| `VoicePaste/OpenAITranscriber.swift` | Add optional `prompt` parameter to init and multipart body |
| `VoicePaste/VoicePasteApp.swift` | Add prompt TextField and save/clear buttons in menu |

## Test plan

- [x] Build succeeds (`xcodebuild -scheme VoicePaste -configuration Release`)
- [x] All 12 tests pass in `test_build.sh`
- [ ] Manual: Click menu bar icon and verify "Transcription Prompt" field is visible
- [ ] Manual: Enter a test prompt and click Save, verify "Saved" indicator appears
- [ ] Manual: Quit and relaunch app, verify the prompt persists
- [ ] Manual: Clear the prompt field and click Save, verify prompt is cleared

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)
